### PR TITLE
Add keyboard repeat pattern explorer web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# KeyboardTesterWasm
+# Keyboard Repeat Pattern Explorer
+
+A lightweight web app for observing how your system generates repeated
+`keydown` events when multiple keys are held simultaneously. Use it to compare
+repeat behavior across keyboards, browsers, and operating systems.
+
+## Live demo
+
+Once this repository is published to GitHub Pages the site will be available at:
+
+```
+https://<your-github-username>.github.io/KeyboardTesterWasm/
+```
+
+(Replace `<your-github-username>` with the account or organization that owns the
+repository.)
+
+## Local development
+
+The site is pure HTML, CSS, and JavaScript located in the [`docs/`](docs)
+folder so it can be deployed via GitHub Pages using the “Deploy from a branch”
+option targeting the `main` branch and `/docs` directory.
+
+To preview locally run a static file server from the repository root, then open
+`http://localhost:8000/docs` in a browser:
+
+```bash
+python3 -m http.server 8000
+```
+
+## How it works
+
+* **Held keys panel** – shows which keys are currently pressed.
+* **Repeat pattern** – displays the order of recent repeated `keydown` events
+  plus a running tally per key.
+* **Event timeline** – logs every `keydown` and `keyup` event with timestamps and
+  inter-event deltas to help you detect rotation patterns or biases.
+
+Use the **Pause capture** toggle to temporarily stop logging without resetting
+existing data, or **Clear log** to reset the session.

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,190 @@
+(function () {
+  const heldKeysList = document.getElementById("held-keys");
+  const noHeldKeysLabel = document.getElementById("no-held-keys");
+  const eventLogBody = document.getElementById("event-log");
+  const patternSequenceEl = document.getElementById("pattern-sequence");
+  const patternCountsEl = document.getElementById("pattern-counts");
+  const clearButton = document.getElementById("clear-log");
+  const pauseToggle = document.getElementById("toggle-pause");
+
+  const activeKeys = new Map();
+  const repeatCounts = new Map();
+  const patternBuffer = [];
+
+  const MAX_LOG_ROWS = 300;
+  const MAX_PATTERN_LENGTH = 80;
+
+  let lastEventTime = null;
+  let originTime = performance.now();
+
+  function formatSeconds(timestamp) {
+    return ((timestamp - originTime) / 1000).toFixed(3);
+  }
+
+  function formatDelta(timestamp) {
+    if (lastEventTime == null) {
+      return "—";
+    }
+    return Math.round(timestamp - lastEventTime).toString();
+  }
+
+  function renderHeldKeys() {
+    heldKeysList.innerHTML = "";
+    if (activeKeys.size === 0) {
+      noHeldKeysLabel.hidden = false;
+      return;
+    }
+
+    noHeldKeysLabel.hidden = true;
+    const fragment = document.createDocumentFragment();
+    for (const keyInfo of activeKeys.values()) {
+      const li = document.createElement("li");
+      const keySpan = document.createElement("span");
+      keySpan.className = "pill-key";
+      keySpan.textContent = keyInfo.key;
+
+      const metaSpan = document.createElement("span");
+      metaSpan.className = "pill-meta";
+      metaSpan.textContent = keyInfo.code;
+
+      li.append(keySpan, metaSpan);
+      fragment.appendChild(li);
+    }
+    heldKeysList.appendChild(fragment);
+  }
+
+  function renderPatternSequence() {
+    if (patternBuffer.length === 0) {
+      patternSequenceEl.textContent = "Waiting for repeated events...";
+      return;
+    }
+
+    const sequence = patternBuffer.map((entry) => entry.label).join(" → ");
+    patternSequenceEl.textContent = sequence;
+  }
+
+  function renderPatternCounts() {
+    patternCountsEl.innerHTML = "";
+
+    if (repeatCounts.size === 0) {
+      return;
+    }
+
+    const items = [...repeatCounts.entries()].sort(
+      (a, b) => b[1].count - a[1].count
+    );
+    const fragment = document.createDocumentFragment();
+
+    for (const [code, data] of items) {
+      const { count, key } = data;
+      const li = document.createElement("li");
+
+      const keySpan = document.createElement("span");
+      keySpan.className = "pill-key";
+      keySpan.textContent = key;
+
+      const metaSpan = document.createElement("span");
+      metaSpan.className = "pill-meta";
+      metaSpan.textContent = `${code} ×${count}`;
+
+      li.append(keySpan, metaSpan);
+      fragment.appendChild(li);
+    }
+
+    patternCountsEl.appendChild(fragment);
+  }
+
+  function appendLogRow({ type, key, code, repeat, timeStamp }) {
+    const row = document.createElement("tr");
+    const delta = formatDelta(timeStamp);
+    const deltaDisplay = delta === "—" ? delta : `${delta} ms`;
+    row.innerHTML = `
+      <td>${formatSeconds(timeStamp)}</td>
+      <td>${deltaDisplay}</td>
+      <td>${type}</td>
+      <td>${key}</td>
+      <td>${code}</td>
+      <td>${repeat ? "yes" : "no"}</td>
+    `;
+    eventLogBody.prepend(row);
+
+    while (eventLogBody.children.length > MAX_LOG_ROWS) {
+      eventLogBody.removeChild(eventLogBody.lastChild);
+    }
+  }
+
+  function handleKeyDown(event) {
+    if (pauseToggle.checked) {
+      return;
+    }
+
+    const { key, code, repeat, timeStamp } = event;
+
+    if (!activeKeys.has(code)) {
+      activeKeys.set(code, { key, code, pressedAt: timeStamp });
+      renderHeldKeys();
+    }
+
+    appendLogRow({ type: "keydown", key, code, repeat, timeStamp });
+    lastEventTime = timeStamp;
+
+    if (repeat) {
+      const label = key.length === 1 ? key : code;
+      patternBuffer.push({ label, timeStamp });
+      if (patternBuffer.length > MAX_PATTERN_LENGTH) {
+        patternBuffer.shift();
+      }
+
+      const existing = repeatCounts.get(code) || { count: 0, key };
+      repeatCounts.set(code, { count: existing.count + 1, key });
+      renderPatternSequence();
+      renderPatternCounts();
+    }
+  }
+
+  function handleKeyUp(event) {
+    if (pauseToggle.checked) {
+      return;
+    }
+
+    const { key, code, timeStamp } = event;
+
+    appendLogRow({ type: "keyup", key, code, repeat: false, timeStamp });
+    lastEventTime = timeStamp;
+
+    if (activeKeys.has(code)) {
+      activeKeys.delete(code);
+      renderHeldKeys();
+    }
+  }
+
+  function resetAll() {
+    activeKeys.clear();
+    repeatCounts.clear();
+    patternBuffer.length = 0;
+    eventLogBody.innerHTML = "";
+    lastEventTime = null;
+    originTime = performance.now();
+    renderHeldKeys();
+    renderPatternSequence();
+    renderPatternCounts();
+  }
+
+  clearButton.addEventListener("click", () => {
+    resetAll();
+    pauseToggle.checked = false;
+  });
+
+  document.body.addEventListener("click", () => {
+    document.body.focus();
+  });
+
+  document.addEventListener("keydown", handleKeyDown, true);
+  document.addEventListener("keyup", handleKeyUp, true);
+
+  document.body.setAttribute("tabindex", "0");
+  document.body.focus();
+
+  renderHeldKeys();
+  renderPatternSequence();
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Keyboard Repeat Pattern Explorer</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Keyboard Repeat Pattern Explorer</h1>
+      <p>
+        Hold down multiple keys simultaneously to observe how your system
+        generates repeated <kbd>keydown</kbd> events. The live log and pattern
+        summary help you determine whether the repeat stream alternates between
+        keys or favors a single key.
+      </p>
+    </header>
+
+    <main class="content">
+      <section class="controls" aria-label="Controls">
+        <button id="clear-log" type="button">Clear log</button>
+        <label class="toggle">
+          <input id="toggle-pause" type="checkbox" />
+          Pause capture
+        </label>
+        <p class="hint">
+          Tip: Click anywhere on the page before testing to ensure it has focus.
+        </p>
+      </section>
+
+      <section class="status" aria-label="Currently held keys">
+        <h2>Held keys</h2>
+        <p id="no-held-keys">No keys are currently held.</p>
+        <ul id="held-keys" class="pill-list" aria-live="polite"></ul>
+      </section>
+
+      <section class="pattern" aria-label="Repeat pattern">
+        <h2>Repeat pattern</h2>
+        <p class="pattern-description">
+          The sequence below shows the most recent keys that produced repeated
+          <kbd>keydown</kbd> events. Use it to spot rotation orders or keys that
+          dominate the repeat stream.
+        </p>
+        <div class="pattern-sequence" id="pattern-sequence" aria-live="polite">
+          Waiting for repeated events...
+        </div>
+        <div class="pattern-stats">
+          <h3>Repeat counts</h3>
+          <ul id="pattern-counts" class="pill-list" aria-live="polite"></ul>
+        </div>
+      </section>
+
+      <section class="log" aria-label="Event log">
+        <h2>Event timeline</h2>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Time (s)</th>
+                <th scope="col">Δ (ms)</th>
+                <th scope="col">Type</th>
+                <th scope="col">Key</th>
+                <th scope="col">Code</th>
+                <th scope="col">Repeat?</th>
+              </tr>
+            </thead>
+            <tbody id="event-log" aria-live="polite"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <footer class="page-footer">
+      <p>
+        Keyboard repeat timing is influenced by your operating system,
+        keyboard firmware, and browser. Compare patterns across devices to learn
+        how they differ.
+      </p>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,232 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.6;
+  background-color: #11161f;
+  color: #e8edf5;
+  --accent: #2e9fff;
+  --accent-muted: rgba(46, 159, 255, 0.3);
+  --surface: rgba(255, 255, 255, 0.04);
+  --surface-strong: rgba(255, 255, 255, 0.08);
+  --shadow: rgba(0, 0, 0, 0.4);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header,
+.page-footer {
+  padding: 2.5rem clamp(1.5rem, 2vw, 3rem);
+  background: linear-gradient(135deg, rgba(46, 159, 255, 0.2), transparent);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.page-header h1 {
+  margin-top: 0;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.page-header p,
+.page-footer p {
+  max-width: 60ch;
+  margin-bottom: 0;
+}
+
+.content {
+  flex: 1;
+  padding: 1.5rem clamp(1.5rem, 2vw, 3rem) 3rem;
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 960px) {
+  .content {
+    grid-template-columns: repeat(12, 1fr);
+    grid-auto-rows: min-content;
+  }
+
+  .controls {
+    grid-column: 1 / span 4;
+  }
+
+  .status {
+    grid-column: 1 / span 4;
+  }
+
+  .pattern {
+    grid-column: 5 / span 8;
+  }
+
+  .log {
+    grid-column: 1 / span 12;
+  }
+}
+
+section {
+  background-color: var(--surface);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 40px -24px var(--shadow), 0 1px 0 rgba(255, 255, 255, 0.05) inset;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+section h2 {
+  margin-top: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  color: rgba(232, 237, 245, 0.75);
+}
+
+.pattern h3 {
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(232, 237, 245, 0.65);
+}
+
+button {
+  background-color: var(--accent);
+  border: none;
+  color: #021321;
+  font-weight: 600;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  box-shadow: 0 12px 24px -12px rgba(46, 159, 255, 0.8);
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px -16px rgba(46, 159, 255, 0.9);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: 1rem;
+  font-size: 0.95rem;
+}
+
+.toggle input[type="checkbox"] {
+  accent-color: var(--accent);
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.hint {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: rgba(232, 237, 245, 0.6);
+}
+
+.pill-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill-list li {
+  background-color: var(--surface-strong);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.9rem;
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.pill-key {
+  font-weight: 600;
+}
+
+.pill-meta {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.pattern-sequence {
+  min-height: 3rem;
+  padding: 1rem;
+  border-radius: 12px;
+  background: var(--surface-strong);
+  font-family: "JetBrains Mono", "Fira Code", "Source Code Pro", monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.table-wrapper {
+  max-height: 360px;
+  overflow: auto;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background-color: rgba(255, 255, 255, 0.05);
+  position: sticky;
+  top: 0;
+  backdrop-filter: blur(8px);
+}
+
+th,
+td {
+  padding: 0.6rem 0.8rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.85rem;
+  font-family: "JetBrains Mono", monospace;
+}
+
+tr:nth-child(even) td {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.log td:nth-child(6) {
+  text-transform: uppercase;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background-color: rgba(46, 159, 255, 0.2);
+  color: #a9d8ff;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  section {
+    padding: 1.1rem;
+  }
+
+  th,
+  td {
+    font-size: 0.75rem;
+  }
+
+  .toggle {
+    margin-left: 0.5rem;
+    font-size: 0.85rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a docs-hosted single-page app for visualizing simultaneous key repeat patterns
- implement styling and visualizations for held keys, repeat sequence, and event log
- refresh the README with GitHub Pages deployment and usage instructions

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e14a914484832690c5c2a4d0a75904